### PR TITLE
fix bug in fetching the data_averaging_period_seconds for v1 endpoint

### DIFF
--- a/openaq_fastapi/openaq_fastapi/routers/locations.py
+++ b/openaq_fastapi/openaq_fastapi/routers/locations.py
@@ -392,7 +392,7 @@ async def latest_v1_get(
                         averagingPeriod: {
                             value: $loc.systems[].sensors[]
                                 | select(.sensors_id==$p.id)
-                                | .sensor_metadata.data_averaging_period_seconds,
+                                | .data_averaging_period_seconds,
                             unit: "seconds"
                             }
                     }


### PR DESCRIPTION
Fixes part of #4 for the /v1/latest endpoint.

Issue with #4 relating to /v2/measurements endpoint is due to the fact that we do not have a data averaging duration for all data (it does not exist at all for Purple Air, CMU, or Habitat Map).