### PR TITLE
Added ability to handle SNS events

### DIFF
--- a/openaq_fastapi/openaq_fastapi/ingest/fetch.py
+++ b/openaq_fastapi/openaq_fastapi/ingest/fetch.py
@@ -315,8 +315,8 @@ def load_db(limit: int = 50, ascending: bool = False):
                 ,last_modified
                 ,fetchlogs_id
                 FROM fetchlogs
-                WHERE key~E'^realtime-gzipped/.*\\.ndjson.gz$' AND
-                completed_datetime is null
+                WHERE key~E'^realtime-gzipped/.*\\.ndjson.gz$'
+                AND completed_datetime is null
                 ORDER BY last_modified {order} nulls last
                 LIMIT %s
                 ;

--- a/openaq_fastapi/openaq_fastapi/ingest/lcs.py
+++ b/openaq_fastapi/openaq_fastapi/ingest/lcs.py
@@ -318,7 +318,7 @@ def load_metadata_bucketscan(count=100):
 
 def load_metadata_db(count=250, ascending: bool = False):
     order = 'ASC' if ascending else 'DESC'
-    with psycopg2.connect(settings.DATABASE_URL) as connection:
+    with psycopg2.connect(settings.DATABASE_WRITE_URL) as connection:
         connection.set_session(autocommit=True)
         with connection.cursor() as cursor:
             cursor.execute(

--- a/openaq_fastapi/openaq_fastapi/ingest/utils.py
+++ b/openaq_fastapi/openaq_fastapi/ingest/utils.py
@@ -168,7 +168,7 @@ def check_if_done(cursor, key):
 
 def get_object(
         key: str,
-        bucket: str = settings.OPENAQ_ETL_BUCKET
+        bucket: str = settings.ETL_BUCKET
 ):
     key = unquote_plus(key)
     text = ''
@@ -187,7 +187,7 @@ def get_object(
 def put_object(
         data: str,
         key: str,
-        bucket: str = settings.OPENAQ_ETL_BUCKET
+        bucket: str = settings.ETL_BUCKET
 ):
     out = io.BytesIO()
     with gzip.GzipFile(fileobj=out, mode='wb') as gz:
@@ -239,7 +239,7 @@ def select_object(key: str):
     content = ""
     logger.debug(f"Getting object: {key}, {output_serialization}")
     resp = s3.select_object_content(
-        Bucket=settings.OPENAQ_ETL_BUCKET,
+        Bucket=settings.ETL_BUCKET,
         Key=key,
         ExpressionType="SQL",
         Expression="""


### PR DESCRIPTION
The purpose of this is to allow us to trigger the ingest lambda (for the fetchlogs) to take advantage of SNS instead of just the S3 trigger. This is currently being tested in staging and therefor has a small hack in it so that it can use the `realtime` SNS notification to register `realtime-gzipped` files. 